### PR TITLE
emit websocket error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ module.exports = class UnifiEvents extends EventEmitter {
 
     ws.on('error', (e) => {
       clearInterval(pingpong)
+      this.emit('websocket-status', `UniFi Events: error - ${e.message}`)
       this._reconnect(e)
     })
   }


### PR DESCRIPTION
I'm using your nice lib (thanks! 😄) in https://github.com/hobbyquaker/unifi2mqtt and I want to log the reason for a connection error so the user knows what went wrong...